### PR TITLE
Fixes for issues #5 and #6

### DIFF
--- a/hardware_usbserial.py
+++ b/hardware_usbserial.py
@@ -35,37 +35,46 @@ class Hardware(BaseHardware):
         except Exception as e:
             print(e)
             raise Exception
+            
+        self.vfo = None
 
+        return None
+        
+    def open(self): # Called once to open the Hardware
         if serialport.isOpen():
-            #Flush input and output buffer, discarding all its contents
+            #Wait for an initial response to verify we're connected
+            if DEBUG == 1:
+            	print("Attempting handshake with RS-HFIQ using *W command...")
+            ver = ''
+            attemptCount = 0
+            while not ( "HFIQ" in ver ):
+                if DEBUG == 1:
+                    print("\t...Attempt "+str(attemptCount+1)+".")
+                if attemptCount > 10:
+                    print("Could not find the RS-HFIQ device. Perhaps wrong usb port ?\nTerminating...")
+                    exit()
+                attemptCount += 1
+                time.sleep(.25)
+                serialport.flushInput()
+                serialport.flushOutput()
+                command='*W\r'
+                serialport.write(command.encode())
+                ver = serialport.readline().strip().decode()
+
+            if DEBUG == 1:
+                print("... Completed handshake with RS-HFIQ.")
             serialport.flushInput()
             serialport.flushOutput()
 
             # Send init string
             command='*OF2\r'
             serialport.write(command.encode())
-
-            # Wait a moment for init to finish
-            time.sleep(1)
-
-        self.vfo = None
-
-        return None
-    def open(self): # Called once to open the Hardware
-        if serialport.isOpen():
-            # Get RS-HFIQ version string
-            serialport.flushInput()
-            serialport.flushOutput()
-            command='*W\r'
-            serialport.write(command.encode())
-            text = serialport.readline()
-            ver=text.strip()
-            print("Retrieved version: ", ver.decode())
-            if "HFIQ" in str(ver.decode()):
-                return str(ver.decode())
-            else :
-                print("Could not find the RS-HFIQ device. Perhaps wrong usb port ?\nTerminating")
-                exit()
+            time.sleep(.25)#FIXME: Possibly some sort of race condition requiring this from time to time
+            serialport.flush()
+            return ver
+        else :
+            print("Failed to open the RS-HFIO serial port. Perhaps wrong usb port?\nTerminating...")
+            exit()
 
     def close(self): # Called once to close the Hardware
         if serialport.isOpen():

--- a/hardware_usbserial.py
+++ b/hardware_usbserial.py
@@ -76,7 +76,7 @@ class Hardware(BaseHardware):
             print("Failed to open the RS-HFIO serial port. Perhaps wrong usb port?\nTerminating...")
             exit()
 
-   def close(self): # Called once to close the Hardware
+    def close(self): # Called once to close the Hardware
         if serialport.isOpen():
             #Ensure we're not left keyed up and shut off the output level
             cmdstr = '*x0\r*Of0\r'

--- a/hardware_usbserial.py
+++ b/hardware_usbserial.py
@@ -76,8 +76,13 @@ class Hardware(BaseHardware):
             print("Failed to open the RS-HFIO serial port. Perhaps wrong usb port?\nTerminating...")
             exit()
 
-    def close(self): # Called once to close the Hardware
+   def close(self): # Called once to close the Hardware
         if serialport.isOpen():
+            #Ensure we're not left keyed up and shut off the output level
+            cmdstr = '*x0\r*Of0\r'
+            serialport.write(cmdstr.encode())
+            time.sleep(.25)#FIXME: Possibly some sort of race condition requiring this from time to time
+            serialport.flush()
             serialport.close()
         return "Closed"
 


### PR DESCRIPTION
Addresses issues #5 and #6 . 

Verifies that the RS-HFIQ connection is interactive before setting oscillator current levels. Still have to use slight delays due to some race condition in Serial/Linux but behavior is much more reliable (on my system anyway).

Also ensures RS-HFIQ is keyed down when Quisk is closed. Keyup may still hang on if Quisk closes with an exception, which I've seen a few times. Not sure what to do about that, as it keeps close() from being invoked and since this is effectively a driver there is no access to the main threads to wrap in an exception and apply a shutdown hook.